### PR TITLE
Add support for auto finishing game turns

### DIFF
--- a/src/java/soc/client/strings/data.properties
+++ b/src/java/soc/client/strings/data.properties
@@ -70,7 +70,7 @@ spec.rsrcs.nwheat = {0,number} wheat
 spec.rsrcs.nwood = {0,number} wood
 spec.rsrcs.nunknown = {0,number} resources of unknown type {1}
 spec.rsrcs.none = nothing
-# For plural forms: Joe monopolized clay / monopolizó la madera
+# For plural forms: Joe monopolized clay / monopolizï¿½ la madera
 spec.rsrcs.clay = clay
 spec.rsrcs.ore = ore
 spec.rsrcs.sheep = sheep
@@ -316,6 +316,7 @@ hpan.one.moment = One moment...
 hpan.quit=Quit
 hpan.roll=Roll
 hpan.roll.autocountdown=Auto-Roll in: {0,number}
+hpan.roll.autofinishcountdown=Finish Turn in: {0, number}
 hpan.roll.rollorplaycard=Roll or Play Card
 hpan.seat.locked = Seat Locked
 hpan.sit.here=Sit Here


### PR DESCRIPTION
Basic testing seems to work --- I reused the roll label to inform the user what was going on.

One problem is if you roll a 7 then you can't auto finish the turn (since you need to play the robber).  I was thinking of then just finding a random place to put the robber.

Also this enforces a strict 5 minute time limit on all turns.  We could have this only kick in if it's auto rolled.